### PR TITLE
using sarama client requires us to commit offset manually

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -100,6 +100,10 @@ func (c *KafkaConsumer) Consume(ctx context.Context, opts messaging.OptionCreato
 			offsetMetrics.
 				WithLabelValues(m.Topic, "consumer", c.groupID, strconv.Itoa(int(m.Partition))).
 				Set(float64(m.Offset))
+			// using consumer group should automatically commit offset
+			if c.groupConsumer != nil {
+				c.groupConsumer.MarkOffset(m, "")
+			}
 		}
 	}
 	if c.singleConsumer != nil {


### PR DESCRIPTION
Since we replaced kafka-go with sarama, committing offset must be done manually. It's also important to note the limitation: 
https://godoc.org/github.com/bsm/sarama-cluster#Consumer.MarkOffset
> calling MarkOffset does not necessarily commit the offset to the backend store immediately for efficiency reasons, and it may never be committed if your application crashes. This means that you may end up processing the same message twice, and your processing should ideally be idempotent.