### PR TITLE
Feat/custome hostname

### DIFF
--- a/example/kafka-sample/main.go
+++ b/example/kafka-sample/main.go
@@ -201,7 +201,7 @@ func sub(rw http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Panic(err)
 		}
-		queue, err = consumer.Consume(context.TODO(), kafka.NewConsumerOption(kafka.OffsetOldest))
+		queue, err = consumer.Consume(context.TODO(), kafka.NewConsumerOption(kafka.OffsetNewest))
 		if err != nil {
 			log.Panic(err)
 		}


### PR DESCRIPTION
After our test, it seems like having kafka_host and kafka_port available via query parameter is a good idea for testing different environments.