### PR TITLE
add constructors that take in old config type

### DIFF
--- a/nsq/config.go
+++ b/nsq/config.go
@@ -1,0 +1,17 @@
+package nsq
+
+import "time"
+
+// Config is the superset of configuration options for all messaging queues.
+// this is the exact copy of old `go-messaging` repo
+type Config struct {
+	Name                string   `json:"name" yaml:"name"`
+	Nsqd                string   `json:"nsqd" yaml:"nsqd"`
+	NsqLogDir           string   `json:"nsqLogDirectory" yaml:"nsqLogDirectory"`
+	Nsqlookupds         []string `json:"nsqlookupds" yaml:"nsqlookupds"`
+	NsqlookupdDiscovery bool     `json:"nsqlookupdDiscovery" yaml:"nsqlookupdDiscovery"`
+	MaxInFlight         int      `json:"maxInFlight" yaml:"maxInFlight"`
+	ConcurrentHandlers  int      `json:"concurrentHandlers" yaml:"concurrentHandlers"`
+	MsgTimeout          int      `json:"msgTimeout" yaml:"msgTimeout"` // seconds
+	MsgTimeoutDuration  time.Duration
+}

--- a/nsq/consumer.go
+++ b/nsq/consumer.go
@@ -14,6 +14,14 @@ type NsqConsumer struct {
 	nsqlookupds []string
 }
 
+// NewConsumer returns an nsq consumer. This is a light wrapper for Consumer constructor that
+// aims for backward compatibility with old `go-messaging` repo`
+func NewConsumer(topic, channel string, config *Config) (*NsqConsumer, error) {
+	return Consumer(topic, channel,
+		[]string{config.Nsqd},
+		config.Nsqlookupds)
+}
+
 func Consumer(topic, channel string, nsqds, nsqlookupds []string) (*NsqConsumer, error) {
 	conf := gnsq.NewConfig()
 	c, err := gnsq.NewConsumer(topic, channel, conf)

--- a/nsq/producer.go
+++ b/nsq/producer.go
@@ -13,6 +13,12 @@ type NsqProducer struct {
 	nsqp *gnsq.Producer
 }
 
+// NewProducer returns an nsq producer. This is a light wrapper for Producer constructor that
+// aims for backward compatibility with old `go-messaging` repo`
+func NewProducer(config *Config) (*NsqProducer, error) {
+	return Producer(config.Nsqd)
+}
+
 func Producer(host string) (*NsqProducer, error) {
 	config := gnsq.NewConfig()
 	p, err := gnsq.NewProducer(host, config)

--- a/nsq/producer.go
+++ b/nsq/producer.go
@@ -16,7 +16,13 @@ type NsqProducer struct {
 // NewProducer returns an nsq producer. This is a light wrapper for Producer constructor that
 // aims for backward compatibility with old `go-messaging` repo`
 func NewProducer(config *Config) (*NsqProducer, error) {
-	return Producer(config.Nsqd)
+	conf := gnsq.NewConfig()
+	conf.MaxInFlight = config.MaxInFlight
+	p, err := gnsq.NewProducer(config.Nsqd, conf)
+	if err != nil {
+		return nil, err
+	}
+	return &NsqProducer{p}, p.Ping()
 }
 
 func Producer(host string) (*NsqProducer, error) {


### PR DESCRIPTION
New `go-messaging-lib` should be able to use current NSQ config type to create consumer/producer.