### PR TITLE
Feat/nsqlookup consul

### DIFF
--- a/example/nsq-sample/main.go
+++ b/example/nsq-sample/main.go
@@ -75,7 +75,10 @@ func pub(rw http.ResponseWriter, r *http.Request) {
 	topic := q.Get("topic")
 	message := q.Get("message")
 
-	producer := nsq.Producer("localhost:4150")
+	producer, err := nsq.Producer("localhost:4150")
+	if err != nil {
+		log.Panic(err)
+	}
 	msg, err := nsq.NewMessage(topic, []byte(message))
 	if err != nil {
 		log.Panic(err)

--- a/nsq/consumer.go
+++ b/nsq/consumer.go
@@ -60,7 +60,7 @@ func Consumer(topic, channel string, nsqds, nsqlookupds []string) (*NsqConsumer,
 func (c *NsqConsumer) Consume(_ context.Context, _ messaging.OptionCreator) (<-chan messaging.Event, error) {
 	msgs := make(chan messaging.Event, 1)
 	c.nsqc.AddHandler(gnsq.HandlerFunc(func(m *gnsq.Message) error {
-		msgs <- &event{m}
+		msgs <- &NsqEvent{m}
 		return nil
 	}))
 

--- a/nsq/message.go
+++ b/nsq/message.go
@@ -58,15 +58,15 @@ func (o *consumerOptions) Options() interface{} {
 	return o
 }
 
-type event struct {
+type NsqEvent struct {
 	*gnsq.Message
 }
 
-func (e *event) Payload() []byte {
+func (e *NsqEvent) Payload() []byte {
 	return e.Body
 }
 
-func (e *event) Metadata() map[string]interface{} {
+func (e *NsqEvent) Metadata() map[string]interface{} {
 	return map[string]interface{}{
 		"timestamp":   e.Timestamp,
 		"NSQDAddress": e.NSQDAddress,
@@ -75,6 +75,6 @@ func (e *event) Metadata() map[string]interface{} {
 	}
 }
 
-func (e *event) Raw() interface{} {
+func (e *NsqEvent) Raw() interface{} {
 	return e.Message
 }


### PR DESCRIPTION
Update example.

Allow NSQ to use consul fir nsq discovery
Make `NsqEvent` public to expose Finish() call.