### PR TITLE
cover edge case when log retention is expired

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -157,6 +157,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "36d6066f3c4d3c5f301dc400d196da44bf49978d14a4dc4be436ab593752529d"
+  inputs-digest = "da125e23f9d56db5fca1727ef9be99c8d9f7e6b5796015cc813357ce4c26a4b0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,18 +24,6 @@
 #   go-tests = true
 #   unused-packages = true
 
-# This should be temporary until Controller feature gets in an official release
-# For now, we'll check in vendor to lock down version. 
-[[override]]
-  name = "github.com/Shopify/sarama"
-  version = "1.17.0"
-
-## This should be temporary 
-[[override]]
-  branch = "master"
-  name = "github.com/bsm/sarama-cluster"
-
-
 [[constraint]]
   name = "github.com/davecgh/go-spew"
   version = "1.1.0"

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -239,12 +239,14 @@ func (m *KafkaManager) perGroup(t, g string, pID int32, availableOffset, oldestO
 	defer partitionOffsetManager.Close()
 	consumerOffset, _ := partitionOffsetManager.NextOffset()
 	var lag int64
-	//no consumer group case / no work to be done
-	if consumerOffset == -1 {
-		if availableOffset > 0 {
-			lag = availableOffset
-		}
-	} else {
+	switch true {
+	case oldestOffset == availableOffset: // no work to be done
+		lag = 0
+	case consumerOffset == -1 && availableOffset > 0: // no consumer group with some work
+		lag = availableOffset
+	case consumerOffset == -1 && availableOffset == 0: // no consumer group and no work
+		lag = 0
+	default:
 		lag = availableOffset - consumerOffset
 	}
 	res := &PartitionInfoContainer{


### PR DESCRIPTION
https://steel-ventures.atlassian.net/browse/VTN-8548

When log retention is expired, Start offset is set based on `auto.offset.reset` configuration. In our case, it sets the Start offset to `latest` causing Start and End offset to be equal, and consequently the Lag value should be 0.

This edge case is accounted for in this PR.
