### PR TITLE
VTN-11012, add option for initial offset

### DIFF
--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -8,8 +8,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
-
-	messaging "github.com/veritone/go-messaging-lib"
+	"github.com/veritone/go-messaging-lib"
 	"github.com/veritone/go-messaging-lib/kafka"
 )
 
@@ -48,7 +47,7 @@ func testConsumerWithGroup(t *testing.T, topic, group string) {
 func testConsumerFromPartition(t *testing.T, topic string, offset int64) {
 	var wg sync.WaitGroup
 	wg.Add(1)
-	c, err := kafka.NewConsumerFromPartition("t2", 0, kafkaHost)
+	c, err := kafka.NewConsumerFromPartition("t2", 0, kafka.OffsetOldest, kafkaHost)
 	assert.NoError(t, err)
 	q, err := c.Consume(context.Background(), kafka.NewConsumerOption(kafka.OffsetOldest))
 	assert.NoError(t, err)
@@ -193,4 +192,89 @@ func TestConsumerManualCommit(t *testing.T) {
 	assert.NoError(t, err, "should have no error")
 	err = producer.Close()
 	assert.NoError(t, err, "should have no error")
+}
+
+func TestConsumerInitialOffsetSetToNewest(t *testing.T) {
+	multiBrokerSetup(t)
+	defer tearDown(t)
+
+	topic := "topic_TestConsumerInitialOffset"
+	broker := "kafka1:9093"
+	producer, err := kafka.Producer(topic, kafka.StrategyRoundRobin, broker)
+	assert.NoError(t, err, "Failed to create Producer")
+
+	// Produce old message
+	msgKeyOld := "key_old_message"
+	msgValueOld := []byte("value_old_message")
+	msgOld, err := kafka.NewMessage(msgKeyOld, msgValueOld)
+	assert.NoError(t, err, "Failed to create kafka message")
+	err = producer.Produce(context.TODO(), msgOld)
+	assert.NoError(t, err, "Failed to produce message to topic")
+
+	// Produce new message
+	msgKeyNew := "key_new_message"
+	msgValueNew := "value_old_message"
+	msgNew, err := kafka.NewMessage(msgKeyNew, []byte(msgValueNew))
+	assert.NoError(t, err, "Failed to create kafka message")
+	err = producer.Produce(context.TODO(), msgNew)
+	assert.NoError(t, err, "Failed to produce message to topic")
+
+	consumerGroupId := "consumerGroup_TestConsumerInitialOffsetSetToNewest"
+	consumer, err := kafka.NewConsumer(topic, consumerGroupId, kafka.WithBrokers(broker), kafka.WithInitialOffset(kafka.OffsetNewest))
+	assert.NoError(t, err, "Failed to create new consumer")
+	msgChan, err := consumer.Consume(context.TODO(), kafka.ConsumerGroupOption)
+	assert.NoError(t, err, "Failed to consume from topic")
+
+	kafkaEvent := <-msgChan
+	kafkaMsg := kafkaEvent.Raw().(*kafka.Message)
+	assert.Equal(t, msgKeyNew, string(kafkaMsg.Key))
+	assert.Equal(t, msgValueNew, kafkaMsg.Value)
+
+	err = consumer.Close()
+	assert.NoError(t, err, "Failed to close consumer")
+}
+
+func TestConsumerInitialOffsetSetToOldest(t *testing.T) {
+	multiBrokerSetup(t)
+	defer tearDown(t)
+
+	topic := "topic_TestConsumerInitialOffset"
+	broker := "kafka1:9093"
+	producer, err := kafka.Producer(topic, kafka.StrategyRoundRobin, broker)
+	assert.NoError(t, err, "Failed to create Producer")
+
+	// Produce old message
+	msgKeyOld := "key_old_message"
+	msgValueOld := []byte("value_old_message")
+	msgOld, err := kafka.NewMessage(msgKeyOld, msgValueOld)
+	assert.NoError(t, err, "Failed to create kafka message")
+	err = producer.Produce(context.TODO(), msgOld)
+	assert.NoError(t, err, "Failed to produce message to topic")
+
+	// Produce new message
+	msgKeyNew := "key_new_message"
+	msgValueNew := []byte("value_old_message")
+	msgNew, err := kafka.NewMessage(msgKeyNew, msgValueNew)
+	assert.NoError(t, err, "Failed to create kafka message")
+	err = producer.Produce(context.TODO(), msgNew)
+	assert.NoError(t, err, "Failed to produce message to topic")
+
+	consumerGroupId := "consumerGroup_TestConsumerInitialOffsetSetToNewest"
+	consumer, err := kafka.NewConsumer(topic, consumerGroupId, kafka.WithBrokers(broker), kafka.WithInitialOffset(kafka.OffsetOldest))
+	assert.NoError(t, err, "Failed to create new consumer")
+	msgChan, err := consumer.Consume(context.TODO(), kafka.ConsumerGroupOption)
+	assert.NoError(t, err, "Failed to consume from topic")
+
+	kafkaEvent0 := <-msgChan
+	kafkaMsg0 := kafkaEvent0.Raw().(*kafka.Message)
+	assert.Equal(t, msgKeyOld, string(kafkaMsg0.Key))
+	assert.Equal(t, msgValueOld, kafkaMsg0.Value)
+
+	kafkaEvent1 := <-msgChan
+	kafkaMsg1 := kafkaEvent1.Raw().(*kafka.Message)
+	assert.Equal(t, msgKeyNew, string(kafkaMsg1.Key))
+	assert.Equal(t, msgValueNew, kafkaMsg1.Value)
+
+	err = consumer.Close()
+	assert.NoError(t, err, "Failed to close consumer")
 }

--- a/kafka/message.go
+++ b/kafka/message.go
@@ -9,11 +9,13 @@ import (
 	messaging "github.com/veritone/go-messaging-lib"
 )
 
-// OffsetOldest lets consumers to retrieve the oldest possible message
-const OffsetOldest = -1
+// OffsetNewest lets consumers retrieve the newest possible message.
+// It must be the same value as defined in sarama.
+const OffsetNewest = -1
 
-// OffsetNewest lets consumers to retrieve the newest possible message
-const OffsetNewest = -2
+// OffsetOldest lets consumers retrieve the oldest possible message.
+// It must be the same value as defined in sarama.
+const OffsetOldest = -2
 
 // Message is a data structure representing kafka messages
 type Message struct {


### PR DESCRIPTION
Added option to set the initial offset to newest when creating a consumer. It defaults to oldest as before the change.