### PR TITLE
vtn-19174 let event chan close on its own

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -362,10 +361,7 @@ func (c *KafkaConsumer) Close() error {
 	}
 
 	if len(errorStrs) > 0 {
-		return fmt.Errorf(
-			"(%d) errors while consuming: %s",
-			len(errorStrs),
-			strings.Join(errorStrs, "\n"))
+		return fmt.Errorf("%d error(s) while consuming from %q: %v", len(errorStrs), c.topic, errorStrs)
 	}
 	return nil
 }


### PR DESCRIPTION
The Close method of the Kafka Consumer calls close on the underlying sarama client and consumer. This causes the returned `messages` chan to close, which in turn closes the `events` chan that is returned by 'Consume()`. Therefore, it's not necessary to explicitly close this chan, as it will cause a panic every time since it's already closed. The recover logic was hiding this.