### PR TITLE
VTN-26109, add StrategyHashMurmur2

### DIFF
--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -18,6 +18,7 @@ func Test_producer_integration(t *testing.T) {
 	//testProducer(t, "t2", kafka.StrategyLeastBytes) // test with LeastBytes
 	testProducer(t, "t3", kafka.StrategyRoundRobin) // test with Round Robin
 	testProducer(t, "t1", kafka.StrategyRoundRobin) // test on existing topic
+	testProducer(t, "t1", kafka.StrategyHashMurmur2)
 
 }
 


### PR DESCRIPTION
[VTN-26109](https://steel-ventures.atlassian.net/browse/VTN-26109)
Since Scheduler is using go-messaging-lib at the moment I thought it's better to edit this repo to add the option for murmur2 hash strategy.